### PR TITLE
Add --max-jobs parameter to limit concurrent SLURM jobs

### DIFF
--- a/autoexperiment/cli.py
+++ b/autoexperiment/cli.py
@@ -36,11 +36,13 @@ def build(config, *, fix:('f', multi()), verbose=1):
           f.write(jobdef.config)
        os.makedirs(os.path.dirname(jobdef.output_file), exist_ok=True)
 
-def run(config, *params, dry=False, verbose=1, fix:('f', multi())):
+def run(config, *params, dry=False, verbose=1, max_jobs:int=None, fix:('f', multi())):
     """
     Manage/schedule jobs corresponding to a config file after
     having generated the sbatch scripts.
     This step requires the 'build' step to have been done first.
+    
+    :param max_jobs: Maximum total jobs in SLURM queue (any state)
     """
     if not config:
          print("Please specify a config file")
@@ -64,14 +66,14 @@ def run(config, *params, dry=False, verbose=1, fix:('f', multi())):
         for jobdef in jobdefs:
             print(jobdef.params["name"])
         return
-    manage_jobs_forever(jobdefs, verbose=verbose)
+    manage_jobs_forever(jobdefs, max_jobs=max_jobs, verbose=verbose)
 
-def build_and_run(config, *params, dry=False, verbose=1, fix:('f', multi())):
+def build_and_run(config, *params, dry=False, verbose=1, max_jobs:int=None, fix:('f', multi())):
     """
     do both above at the same time, for simplicity
     """
     build(config, fix=fix, verbose=verbose)
-    run(config, *params, dry=dry, verbose=verbose, fix=fix)
+    run(config, *params, dry=dry, verbose=verbose, fix=fix, max_jobs=max_jobs)
 
 def for_each(config, cmd):
     jobdefs = generate_job_defs(config)


### PR DESCRIPTION
Solves Issue #8 
## Summary
- Add JobLimitsManager class to manage job submission limits with async coordination
- Support `--max-jobs` parameter in `run` and `build-and-run` commands  
- Implement async job queuing when limits are reached to prevent SLURM overload
- Handle all job lifecycle events (submit, finish, scancel) properly to avoid counter drift
- Fix edge case for `max_jobs=0` to correctly block all job submissions

## Usage
```bash
# Limit to 5 total jobs in SLURM queue (any state: pending, running, etc.)
autoexperiment run config.yaml --max-jobs 5

# Combined build and run with limits
autoexperiment build-and-run config.yaml --max-jobs 3
```

## Technical Details
- Uses `asyncio.Condition` for efficient job waiting without busy polling
- Thread-safe counter management with proper async coordination
- Backward compatible - no limits when `--max-jobs` not specified
- Handles job relaunches correctly without double-counting
- Properly decrements counter when jobs are cancelled due to freezing

## Test plan
- [x] Basic syntax check and CLI help verification
- [x] JobLimitsManager unit test verification  
- [x] End-to-end testing with actual SLURM jobs
- [x] Verify job limiting behavior under various scenarios
- [x] Test job relaunch scenarios maintain correct counters

🤖 Generated with [Claude Code](https://claude.ai/code)